### PR TITLE
Add loader for LIDC

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,17 +1,22 @@
-from medpy.io import load
-import matplotlib.pyplot as plt
-import matplotlib.cm as cm
-import skimage.feature as skimg
-import numpy as np
-from sklearn.metrics.cluster import entropy
+#from medpy.io import load
+#import matplotlib.pyplot as plt
+#import matplotlib.cm as cm
+#import skimage.feature as skimg
+#import numpy as np
+#from sklearn.metrics.cluster import entropy
 
 from util import parser
 
+import util as util
+
 if __name__ == '__main__':
     file_to_process = '208.xml'
+
+    util.load_nodules("lidc-data/", "LIDC")
+
     # Two examples; govnofull gives you matrix + image + header, govno just matrix
-    govnoFull = parser.LidcParser().get_data(file_to_process)
-    govnoMatrix = parser.LidcParser().parse_file('lidc-data/' + file_to_process)
+    #govnoFull = parser.LidcParser().get_data(file_to_process)
+    #govnoMatrix = parser.LidcParser().parse_file('lidc-data/' + file_to_process)
 
     # i, h = load("000208.dcm")
     # print(i.shape, i.dtype)

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,0 +1,2 @@
+from loader import Nodule, load_nodules
+from parser import *

--- a/util/loader.py
+++ b/util/loader.py
@@ -1,0 +1,122 @@
+import os as os
+import numpy as np
+import medpy.io as medpy
+import lxml.etree as lxml
+
+
+SUPPORTED_DATASETS = ["LIDC"]
+
+
+class Nodule:
+    def __init__(self):
+        # width or height of image
+        size = 0
+
+        # source image ID and slice
+        source_id = ""
+        source_slice = ""
+
+        # coordinates from source image
+        source_x = 0
+        source_y = 0
+
+        # pixels of image
+        pixels = np.array([])
+
+        # is malignant?
+        malignant = False
+
+
+def load_nodules(dataset_path, dataset_type, debug=False):
+    full_path = os.path.realpath(dataset_path)
+
+    nodules = []
+    if dataset_type == 'LIDC':
+        nodules = load_lidc(full_path, debug)
+    else:
+        raise Exception('Dataset_type is wrong')
+
+    return nodules
+
+
+def get_all_files(path, ending=""):
+    paths = []
+
+    for root, dirs, files in os.walk(path):
+        for file_path in files:
+            if file_path.endswith(ending):
+                full_path = os.path.join(root, file_path)
+                paths.append(full_path)
+
+    return paths
+
+
+class LidcImage:
+    def __init__(self):
+        id = ""
+        fullpath = ""
+        slice_location = ""
+        pixels = np.array([])
+
+
+def load_lidc(dataset_path, debug):
+    img_paths = get_all_files(dataset_path, '.dcm')
+    ann_paths = get_all_files(dataset_path, '.xml')
+
+    lids_images = []
+
+    for path in img_paths:
+        image = LidcImage()
+
+        pixels, header = medpy.load(path)
+
+        image.pixels = pixels
+        image.id = header.data_element("SOPInstanceUID").value
+        image.fullpath = path
+        image.slice_location = header.data_element("SliceLocation").value
+
+        lids_images.append(image)
+
+    nodules = []
+
+
+    for path in ann_paths:
+        tree = lxml.parse(path)
+        root_node = tree.getroot()
+
+
+        for roi_node in root_node.iter('roi'):
+            ann_id = roi_node.find('imageSOP_UID').text
+            ann_slice = '0'
+            ann_x = int(roi_node.find('edgeMap').find('xCoord').text)
+            ann_y = int(roi_node.find('edgeMap').find('yCoord').text)
+            ann_malignant = roi_node.find('inclusion').text
+
+            slice_node = roi_node.find('imageZposition')
+            if slice_node is not None:
+                ann_slice = slice_node.text
+
+            img = None
+            for i in lids_images:
+                print(i.id, ann_id)
+                if i.id == ann_id and (ann_slice == '0' or i.slice_location == ann_slice):
+                    img = i
+
+            if img is None:
+                if debug:
+                    print("Image for nodule " + ann_id + " not found.")
+            else:
+                nodule = Nodule
+
+                s = 32
+                nodule.size = s * 2
+                nodule.pixels = img.pixels[ann_y - s: ann_y + s, ann_x - s: ann_x + s]
+                nodule.source_id = ann_id
+                nodule.source_slice = ann_slice
+                nodule.source_x = ann_x
+                nodule.source_y = ann_y
+                nodule.malignant = ann_malignant
+
+                nodules.append(nodule)
+
+    return nodules


### PR DESCRIPTION
Добавил загрузчик LIDC. Ищет рекурсивно все анотации в указанной директории и по ним выгружает массив с объектами Nodule.

Nodule - содержит описание узелка и его изображение.

```Python
def load_nodules(dataset_path, dataset_type, debug=False)
```
* dataset_path - путь до датасета,
* dataset_type - тип датасета (пока только "LIDC").